### PR TITLE
enhance static linking to libssh2 and allow shared

### DIFF
--- a/3rdparty/3rdparty.pri
+++ b/3rdparty/3rdparty.pri
@@ -7,7 +7,7 @@ win32-msvc* {
     } else {
         error("Your msvc version is not suppoted. qredisclient requires msvc2015")
     }
-    
+
     LIBSSH_LIB_PATH = $$PWD/libssh2/build/src/release
 
     defined(OPENSSL_STATIC) {
@@ -19,13 +19,13 @@ win32-msvc* {
     LIBS += -L$$LIBSSH_LIB_PATH -L$$OPENSSL_LIB_PATH -llibssh2 -llibeay32MD -lgdi32 -lws2_32 -lkernel32 -luser32 -lshell32 -luuid -lole32 -ladvapi32
 } else {
 
-   exists( /usr/local/lib64/libssh2.a ) {    
-      LIBS += /usr/local/lib64/libssh2.a
+   exists( $$PWD/libssh2/bin/src/libssh2.a ) {
+      LIBS += $$PWD/libssh2/bin/src/libssh2.a
    } else {
-      LIBS += /usr/local/lib/libssh2.a
+      LIBS += -lssh2
    }
 
-   LIBS += -lz -lssl -lcrypto 
+   LIBS += -lz -lssl -lcrypto
 
    unix:mac {
       INCLUDEPATH += /usr/local/opt/openssl/include

--- a/configure
+++ b/configure
@@ -10,7 +10,6 @@ function build_libssh2 {
         cd bin
         cmake -DCRYPTO_BACKEND=OpenSSL -DENABLE_ZLIB_COMPRESSION=ON ..
         cmake --build .
-        sudo make install
     fi
 }
 


### PR DESCRIPTION
There is no need to "install" when you are using the static lib, so just
point to the correct build location where libssh2.a can be found. If the
static lib is not found use the system wide shared libssh2.so

Signed-off-by: BlackEagle <ike.devolder@gmail.com>